### PR TITLE
fix: update kops provider source and version

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,10 +1,9 @@
 terraform {
   required_providers {
     kops = {
-      source  = "eddycharly/kops"
-      version = "~>1.22"
+      source  = "terraform-kops/kops"
+      version = "~> 1.31"
     }
-
     aws = {
       source  = "hashicorp/aws"
       version = "~> 6.0"


### PR DESCRIPTION
Change the kops provider source to "terraform-kops/kops" and 
update the version to "~> 1.31" for better compatibility and 
improvements in the latest release.