### PR TITLE
feat: add tags variable for AWS SecretsManager secret

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@ data "kops_kube_config" "kube_config" {
 
 resource "aws_secretsmanager_secret" "cluster_secret" {
   name = "argocd/clusters/${var.cluster_name}"
+  tags = var.tags
 }
 
 resource "aws_secretsmanager_secret_version" "cluster_secret_value" {

--- a/vars.tf
+++ b/vars.tf
@@ -14,3 +14,9 @@ variable "role_arn" {
   type        = string
   description = "the ARN of the role to give access to the cluster, for example arn:aws:iam::12456789012:role/KubernetesAdmin"
 }
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "tags to apply to the secret in AWS SecretsManager"
+}


### PR DESCRIPTION
## Summary

Adds an optional `tags` map variable that is forwarded to the
`aws_secretsmanager_secret` resource. Default `{}` so existing
callers see no change.

## Why

Consumers (e.g. `opzkit/terraform-aws-k8s-addons-argocd-cluster-secrets`) read tags from each
`argocd/clusters/*` secret and template them as Kubernetes labels on
the resulting ArgoCD cluster Secret. Without a tags input, the only
ways to get those labels were AWS provider `default_tags` (pollutes
unrelated resources) or manual `aws secretsmanager tag-resource`
(operational drift). This variable makes the labelling declarative.

Concrete near-term use case: adding a `Provider=aws` tag to label
ArgoCD cluster Secrets so multi-cloud ApplicationSets can select
clusters by provider.

## Test plan

- [x] `terraform validate` green
- [ ] CI workflow + checkov pass on this PR
- [ ] Existing callers (default `{}`) see no plan diff after bump