### PR TITLE
feat: make secret recovery window configurable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,8 +3,9 @@ data "kops_kube_config" "kube_config" {
 }
 
 resource "aws_secretsmanager_secret" "cluster_secret" {
-  name = "argocd/clusters/${var.cluster_name}"
-  tags = var.tags
+  name                    = "argocd/clusters/${var.cluster_name}"
+  recovery_window_in_days = var.recovery_window_in_days
+  tags                    = var.tags
 }
 
 resource "aws_secretsmanager_secret_version" "cluster_secret_value" {

--- a/vars.tf
+++ b/vars.tf
@@ -20,3 +20,14 @@ variable "tags" {
   default     = {}
   description = "tags to apply to the secret in AWS SecretsManager"
 }
+
+variable "recovery_window_in_days" {
+  type        = number
+  default     = 30
+  description = "Number of days AWS Secrets Manager waits before permanently deleting the secret. Set to 0 to delete immediately (useful for ephemeral clusters that get rebuilt frequently). Otherwise must be between 7 and 30."
+
+  validation {
+    condition     = var.recovery_window_in_days == 0 || (var.recovery_window_in_days >= 7 && var.recovery_window_in_days <= 30)
+    error_message = "recovery_window_in_days must be 0 or between 7 and 30."
+  }
+}


### PR DESCRIPTION
## Summary
- Add `recovery_window_in_days` variable wired into `aws_secretsmanager_secret.cluster_secret`.
- Default `30` (AWS default) preserves existing behavior; `0` enables immediate deletion for ephemeral clusters (staging) that get rebuilt frequently and need to reuse the same secret name.
- Validation enforces AWS-allowed values: `0` or `7-30`.

## Test plan
- [x] `terraform fmt -check`
- [x] `terraform validate`
- [x] `prek run --all-files`
- [ ] Consumer module sets `recovery_window_in_days = 0` in staging; verify destroy + apply cycle reuses secret name without `InvalidRequestException`.
